### PR TITLE
fix exception in log_apex_items

### DIFF
--- a/source/packages/logger.pkb
+++ b/source/packages/logger.pkb
@@ -488,7 +488,6 @@ as
     l_text 				varchar2(32767);
     l_callstack         varchar2(3000);
     l_extra logger_logs.extra%type;
-    l_id logger_logs.id%type;
   begin
     $IF $$NO_OP $THEN
       null;
@@ -516,7 +515,7 @@ as
         p_text =>l_text,
         p_call_stack  =>l_callstack,
         p_line_no => l_lineno,
-        po_id => l_id);
+        po_id => g_log_id);
 --      commit;
     $END
   end log_internal;


### PR DESCRIPTION
When trying to use the `log_apex_items` with the most recent release 2.1.2, I was getting the following error:

```
  ORA-01400: cannot insert NULL into ("HR"."LOGGER_LOGS_APEX_ITEMS"."LOG_ID")
```

It looks like the `log_internal` procedure needs to ensure the `g_log_id` is set properly in order for `log_apex_items` to work as expected.

With this change I'm seeing the APEX session items in LOGGER_LOGS_APEX_ITEMS as expected.
