### PR TITLE
Adds XMLTYPE and DATE signatures

### DIFF
--- a/source/packages/logger.pkb
+++ b/source/packages/logger.pkb
@@ -700,7 +700,6 @@ as
   
         l_text := l_text || dbms_utility.format_error_stack();
         
-        
         l_extra := set_extra_with_params(p_extra => p_extra, p_params => p_params);
         
         ins_logger_logs(
@@ -716,7 +715,30 @@ as
     $END
 	end log_error;
 
+  procedure log_error(
+    p_xmltype       in XMLTYPE default null,
+    p_scope         in varchar2 default null,
+    p_params        in tab_param default logger.gc_empty_tab_param)
+  is
+  begin
+    log_error (
+      p_scope   =>      p_scope,
+      p_extra   =>      p_xmltype.getclobval(),
+      p_params  =>      p_params);
+  end log_error;
 
+  procedure log_error(
+    p_date          in date default null,
+    p_scope         in varchar2 default null,
+    p_params        in tab_param default logger.gc_empty_tab_param)
+  is
+  begin
+    log_error (
+      p_text    =>      logger.tochar (p_date),
+      p_scope   =>      p_scope,
+      p_params  =>      p_params);
+  end log_error;
+  
   procedure log_permanent(
     p_text    in varchar2,
     p_scope   in varchar2 default null,
@@ -740,7 +762,31 @@ as
     $END
   end log_permanent;
 
+  procedure log_permanent(
+    p_xmltype       in XMLTYPE default null,
+    p_scope         in varchar2 default null,
+    p_params        in tab_param default logger.gc_empty_tab_param)
+  is
+  begin
+    log_permanent (
+      p_text    =>  NULL,
+      p_scope   =>  p_scope,
+      p_extra   =>  p_xmltype.getclobval(),
+      p_params  =>  p_params);
+  end log_permanent;
 
+  procedure log_permanent(
+    p_date          in date default null,
+    p_scope         in varchar2 default null,
+    p_params        in tab_param default logger.gc_empty_tab_param)
+  is
+  begin
+    log_permanent (
+      p_text    =>      logger.tochar (p_date),
+      p_scope   =>      p_scope,
+      p_params  =>      p_params);
+  end log_permanent;
+  
   procedure log_warning(
     p_text    in varchar2,
     p_scope   in varchar2 default null,
@@ -761,6 +807,31 @@ as
           p_params => p_params);
       end if;
     $END
+  end log_warning;
+
+  procedure log_warning(
+    p_xmltype       in XMLTYPE default null,
+    p_scope         in varchar2 default null,
+    p_params        in tab_param default logger.gc_empty_tab_param)
+  is
+  begin
+    log_warning (
+      p_text    =>  NULL,
+      p_scope   =>  p_scope,
+      p_extra   =>  p_xmltype.getclobval(),
+      p_params  =>  p_params);
+  end log_warning;
+
+  procedure log_warning(
+    p_date          in date default null,
+    p_scope         in varchar2 default null,
+    p_params        in tab_param default logger.gc_empty_tab_param)
+  is
+  begin
+    log_warning (
+      p_text    =>      logger.tochar (p_date),
+      p_scope   =>      p_scope,
+      p_params  =>      p_params);
   end log_warning;
 
   procedure log_information(
@@ -785,6 +856,31 @@ as
     $END
 	end log_information;
 
+  procedure log_information(
+    p_xmltype       in XMLTYPE default null,
+    p_scope         in varchar2 default null,
+    p_params        in tab_param default logger.gc_empty_tab_param)
+  is
+  begin
+    log_information (
+      p_text    =>  NULL,
+      p_scope   =>  p_scope,
+      p_extra   =>  p_xmltype.getclobval(),
+      p_params  =>  p_params);
+  end log_information;
+
+  procedure log_information(
+    p_date          in date default null,
+    p_scope         in varchar2 default null,
+    p_params        in tab_param default logger.gc_empty_tab_param)
+  is
+  begin
+    log_information (
+      p_text    =>      logger.tochar (p_date),
+      p_scope   =>      p_scope,
+      p_params  =>      p_params);
+  end log_information;
+
 	procedure log(
     p_text    in varchar2,
     p_scope   in varchar2 default null,
@@ -792,7 +888,6 @@ as
     p_params  in tab_param default logger.gc_empty_tab_param)
 	is
 	begin
-    
     $IF $$NO_OP $THEN
       null;
     $ELSE
@@ -807,6 +902,31 @@ as
       end if;
     $END
 	end log;
+
+  procedure log(
+    p_xmltype       in XMLTYPE default null,
+    p_scope         in varchar2 default null,
+    p_params        in tab_param default logger.gc_empty_tab_param)
+  is
+  begin
+    log (
+      p_text    =>  NULL,
+      p_scope   =>  p_scope,
+      p_extra   =>  p_xmltype.getclobval(),
+      p_params  =>  p_params);
+  end log;
+
+  procedure log(
+    p_date          in date default null,
+    p_scope         in varchar2 default null,
+    p_params        in tab_param default logger.gc_empty_tab_param)
+  is
+  begin
+    log (
+      p_text    =>      logger.tochar (p_date),
+      p_scope   =>      p_scope,
+      p_params  =>      p_params);
+  end log;
 
   function get_sys_context(
     p_detail_level in varchar2 default 'USER', -- ALL, NLS, USER, INSTANCE
@@ -833,7 +953,6 @@ as
       end if;
     exception 
       when invalid_userenv_parm then
-        --log_warning('Invalid SYS_CONTEXT Parameter: '||p_name);
         null;
     end append_ctx;
 
@@ -933,7 +1052,7 @@ as
         l_cgienv := l_cgienv || rpad(p_name,r_pad,' ')||': '||p_val||l_crlf;
 			end if;
       --exception when invalid_userenv_parm then
-      --log_warning('Invalid SYS_CONTEXT Parameter: '||p_name);
+
       null;
     end append_cgi_env;
 

--- a/source/packages/logger.pks
+++ b/source/packages/logger.pks
@@ -3,14 +3,15 @@ create or replace package logger
 as
   -- This project using the following Revised BSD License:
   --
-  -- Copyright (c) 2013, Tyler D. Muth, tylermuth.wordpress.com 
-  -- and contributors to the project at 
+  -- Copyright (c) 2013, Tyler D. Muth, tylermuth.wordpress.com
+  -- and contributors to the project at
   -- https://github.com/tmuth/Logger---A-PL-SQL-Logging-Utility
   -- All rights reserved.
   --
   -- Project Contributors
   --  - Martin Giffy D'Souza: http://www.talkapex.com
-  -- 
+  --  - João Barreto
+  --
   -- Redistribution and use in source and binary forms, with or without
   -- modification, are permitted provided that the following conditions are met:
   --     * Redistributions of source code must retain the above copyright
@@ -21,7 +22,7 @@ as
   --     * Neither the name of Tyler D Muth, nor Oracle Corporation, nor the
   --       names of its contributors may be used to endorse or promote products
   --       derived from this software without specific prior written permission.
-  -- 
+  --
   -- THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
   -- ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
   -- WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -37,13 +38,13 @@ as
   type rec_param is record(
     name varchar2(255),
     val varchar2(4000));
-  
+
   type tab_param is table of rec_param index by binary_integer;
-  
+
   -- VARIABLES
 	g_logger_version constant varchar2(10) := 'x.x.x'; -- Don't change this. Build script will replace with right version number
 	g_context_name constant varchar2(35) := substr(sys_context('USERENV','CURRENT_SCHEMA'),1,23)||'_LOGCTX';
-  
+
   g_off constant number := 0;
   g_permanent constant number := 1;
 	g_error constant number := 2;
@@ -69,7 +70,7 @@ as
 
 
   -- PROCEDURES and FUNCTIONS
-  
+
   procedure null_global_contexts;
 
   function convert_level_char_to_num(
@@ -94,10 +95,30 @@ as
     p_extra         in clob default null,
     p_params        in tab_param default logger.gc_empty_tab_param);
 
+  procedure log_error(
+    p_xmltype       in XMLTYPE default null,
+    p_scope         in varchar2 default null,
+    p_params        in tab_param default logger.gc_empty_tab_param);
+
+  procedure log_error(
+    p_date          in date default null,
+    p_scope         in varchar2 default null,
+    p_params        in tab_param default logger.gc_empty_tab_param);
+
   procedure log_permanent(
     p_text    in varchar2,
     p_scope   in varchar2 default null,
     p_extra   in clob default null,
+    p_params  in tab_param default logger.gc_empty_tab_param);
+
+  procedure log_permanent(
+    p_xmltype       in XMLTYPE default null,
+    p_scope         in varchar2 default null,
+    p_params  in tab_param default logger.gc_empty_tab_param);
+
+  procedure log_permanent(
+    p_date          in date default null,
+    p_scope         in varchar2 default null,
     p_params  in tab_param default logger.gc_empty_tab_param);
 
   procedure log_warning(
@@ -106,16 +127,46 @@ as
     p_extra   in clob default null,
     p_params  in tab_param default logger.gc_empty_tab_param);
 
+  procedure log_warning(
+    p_xmltype       in XMLTYPE default null,
+    p_scope         in varchar2 default null,
+    p_params  in tab_param default logger.gc_empty_tab_param);
+
+  procedure log_warning(
+    p_date          in date default null,
+    p_scope         in varchar2 default null,
+    p_params  in tab_param default logger.gc_empty_tab_param);
+
   procedure log_information(
     p_text    in varchar2,
     p_scope   in varchar2 default null,
     p_extra   in clob default null,
     p_params  in tab_param default logger.gc_empty_tab_param);
 
+  procedure log_information(
+    p_xmltype       in XMLTYPE default null,
+    p_scope         in varchar2 default null,
+    p_params  in tab_param default logger.gc_empty_tab_param);
+
+  procedure log_information(
+    p_date          in date default null,
+    p_scope         in varchar2 default null,
+    p_params  in tab_param default logger.gc_empty_tab_param);
+
   procedure log(
     p_text    in varchar2,
     p_scope   in varchar2 default null,
     p_extra   in clob default null,
+    p_params  in tab_param default logger.gc_empty_tab_param);
+
+  procedure log(
+    p_xmltype       in XMLTYPE default null,
+    p_scope         in varchar2 default null,
+    p_params  in tab_param default logger.gc_empty_tab_param);
+
+  procedure log(
+    p_date          in date default null,
+    p_scope         in varchar2 default null,
     p_params  in tab_param default logger.gc_empty_tab_param);
 
   function get_cgi_env(
@@ -147,14 +198,14 @@ as
 	procedure time_stop(
 		p_unit				IN VARCHAR2,
     p_scope             in varchar2 default null);
-        
+
   function time_stop(
     p_unit				IN VARCHAR2,
     p_scope             in varchar2 default null,
     p_log_in_table 	    IN boolean default true
     )
     return varchar2;
-        
+
   function time_stop_seconds(
     p_unit				in varchar2,
     p_scope             in varchar2 default null,
@@ -193,11 +244,11 @@ as
     p_include_call_stack in varchar2 default null,
     p_client_id_expire_hours in number default null
   );
-    
+
   procedure unset_client_level(p_client_id in varchar2);
-  
+
   procedure unset_client_level;
-  
+
   procedure unset_client_level_all;
 
 
@@ -226,37 +277,37 @@ as
     return varchar2;
 
 
-  
+
   procedure append_param(
     p_params in out nocopy logger.tab_param,
     p_name in varchar2,
     p_val in varchar2);
-    
+
   procedure append_param(
     p_params in out nocopy logger.tab_param,
     p_name in varchar2,
     p_val in number);
-    
+
   procedure append_param(
     p_params in out nocopy logger.tab_param,
     p_name in varchar2,
     p_val in date);
-    
+
   procedure append_param(
     p_params in out nocopy logger.tab_param,
     p_name in varchar2,
     p_val in timestamp);
-    
+
   procedure append_param(
     p_params in out nocopy logger.tab_param,
     p_name in varchar2,
     p_val in timestamp with time zone);
-    
+
   procedure append_param(
     p_params in out nocopy logger.tab_param,
     p_name in varchar2,
     p_val in timestamp with local time zone);
-    
+
   procedure append_param(
     p_params in out nocopy logger.tab_param,
     p_name in varchar2,
@@ -264,22 +315,21 @@ as
 
   function ok_to_log(p_level in number)
     return boolean;
-    
+
   function ok_to_log(p_level in varchar2)
     return boolean;
-    
+
   procedure ins_logger_logs(
     p_logger_level in logger_logs.logger_level%type,
     p_text in varchar2 default null, -- Not using type since want to be able to pass in 32767 characters
     p_scope in logger_logs.scope%type default null,
     p_call_stack in logger_logs.call_stack%type default null,
     p_unit_name in logger_logs.unit_name%type default null,
-    p_line_no in logger_logs.line_no%type default null, 
+    p_line_no in logger_logs.line_no%type default null,
     p_extra in logger_logs.extra%type default null,
     po_id out nocopy logger_logs.id%type
   );
-  
-  
+
   function get_fmt_msg(
     p_msg in varchar2,
     p_s01 in varchar2 default null,

--- a/source/packages/logger_no_op.pkb
+++ b/source/packages/logger_no_op.pkb
@@ -663,6 +663,96 @@ display_output('Debug Level','NO-OP, Logger completely disabled.');
   begin
     null;
   end append_param;
+
+  procedure log_error(
+    p_xmltype       in XMLTYPE default null,
+    p_scope         in varchar2 default null,
+    p_params        in tab_param default logger.gc_empty_tab_param)
+  is
+  begin
+    null;
+  end log_error;
   
+  procedure log_error(
+    p_date          in date default null,
+    p_scope         in varchar2 default null,
+    p_params        in tab_param default logger.gc_empty_tab_param)
+  is
+  begin
+    null;
+  end log_error;
+  
+  procedure log_permanent(
+    p_xmltype       in XMLTYPE default null,
+    p_scope         in varchar2 default null,
+    p_params        in tab_param default logger.gc_empty_tab_param)
+  is
+  begin
+    null;
+  end log_permanent;
+  
+  procedure log_permanent(
+    p_date          in date default null,
+    p_scope         in varchar2 default null,
+    p_params        in tab_param default logger.gc_empty_tab_param)
+  is
+  begin
+    null;
+  end log_permanent;
+  
+  procedure log_warning(
+    p_xmltype       in XMLTYPE default null,
+    p_scope         in varchar2 default null,
+    p_params        in tab_param default logger.gc_empty_tab_param)
+  is
+  begin
+    null;
+  end log_warning;
+  
+  procedure log_warning(
+    p_date          in date default null,
+    p_scope         in varchar2 default null,
+    p_params        in tab_param default logger.gc_empty_tab_param)
+  is
+  begin
+    null;
+  end log_warning;
+  
+  procedure log_information(
+    p_xmltype       in XMLTYPE default null,
+    p_scope         in varchar2 default null,
+    p_params        in tab_param default logger.gc_empty_tab_param)
+  is
+  begin
+    null;
+  end log_information;
+  
+  procedure log_information(
+    p_date          in date default null,
+    p_scope         in varchar2 default null,
+    p_params        in tab_param default logger.gc_empty_tab_param)
+  is
+  begin
+    null;
+  end log_information;
+  
+  procedure log(
+    p_xmltype       in XMLTYPE default null,
+    p_scope         in varchar2 default null,
+    p_params        in tab_param default logger.gc_empty_tab_param)
+  is
+  begin
+    null;
+  end log;
+  
+  procedure log(
+    p_date          in date default null,
+    p_scope         in varchar2 default null,
+    p_params        in tab_param default logger.gc_empty_tab_param)
+  is
+  begin
+    null;
+  end log;
+
 end logger;
 /


### PR DESCRIPTION
Useful to reduce the length of log code in business code. Also centralizes conversions avoiding implicit ones.
